### PR TITLE
SUW: Change WizardManager activity default state to disabled

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2013 The CyanogenMod Project
-     Copyright (C) 2017 The LineageOS Project
+     Copyright (C) 2017,2019 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@
         <activity android:theme="@style/NoDisplay"
                   android:label="@string/activity_label_empty"
                   android:name=".wizardmanager.WizardManager"
+                  android:enabled="false"
                   android:exported="false"
                   android:excludeFromRecents="true"
                   android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize"

--- a/src/org/lineageos/setupwizard/SetupWizardActivity.java
+++ b/src/org/lineageos/setupwizard/SetupWizardActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 The CyanogenMod Project
- * Copyright (C) 2017 The LineageOS Project
+ * Copyright (C) 2017,2019 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,17 +43,14 @@ public class SetupWizardActivity extends BaseSetupWizardActivity {
             Log.v(TAG, "onCreate savedInstanceState=" + savedInstanceState);
         }
         if (SetupWizardUtils.hasGMS(this)) {
-            if (LOGV) {
-                Log.v(TAG, "Has GMS disabling local wizard manager");
-            }
-            SetupWizardUtils.disableComponentsForGMS(this);
+            SetupWizardUtils.disableHome(this);
             finish();
         } else if (WizardManagerHelper.isUserSetupComplete(this)) {
             SetupWizardUtils.finishSetupWizard(this);
             finish();
         } else {
             onSetupStart();
-            SetupWizardUtils.resetComponent(this, WizardManager.class);
+            SetupWizardUtils.enableComponent(this, WizardManager.class);
             Intent intent = new Intent(ACTION_LOAD);
             if (isPrimaryUser()) {
                 intent.putExtra(EXTRA_SCRIPT_URI, getString(R.string.lineage_wizard_script_uri));

--- a/src/org/lineageos/setupwizard/util/SetupWizardUtils.java
+++ b/src/org/lineageos/setupwizard/util/SetupWizardUtils.java
@@ -263,11 +263,6 @@ public class SetupWizardUtils {
         }
     }
 
-    public static void disableComponentsForGMS(Context context) {
-        disableComponent(context, WizardManager.class);
-        disableHome(context);
-    }
-
     public static void disableHome(Context context) {
         ComponentName homeComponent = getHomeComponent(context);
         if (homeComponent != null) {


### PR DESCRIPTION
Google's suw handles the LOAD and NEXT actions, so this creates
duplicate tasks and crashes google suw when finish() is attempted.

Change-Id: Ifdbd9365fba7f299dc041e42ae27a91da071aa99