### PR TITLE
SUW: Don't make google suw use material_light

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2013-2015 The CyanogenMod Project
-     Copyright (C) 2017 The LineageOS Project
+     Copyright (C) 2017,2019 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@
     <string name="lineage_wizard_script_uri" translatable="false">android.resource://org.lineageos.setupwizard/raw/lineage_wizard_script</string>
     <string name="lineage_wizard_script_user_uri" translatable="false">android.resource://org.lineageos.setupwizard/raw/lineage_wizard_script_user</string>
 
-    <!-- Partner SUW Strings -->
-    <string name="theme_type" translatable="false">material_light</string>
     <string name="activity_label_empty" />
 
     <string name="next">Next</string>


### PR DESCRIPTION
The material_light theme causes gms to crash with "Error inflating
class TextView" when attempting to do a device to device restore in
google suw. This change allows it to use the default glif_light.

Also removed the "Partner SUW Strings" comment, as the theme_type
was the only one.

Change-Id: I287f201799aba81c19869000e3aadb47ef67299b
(cherry picked from commit 2f9034668b56722d4e0cbf464495c93e6ba429ce)